### PR TITLE
Adding the TrendPy Webapp

### DIFF
--- a/TrendPy/TrendPy_Webapp.ipynb
+++ b/TrendPy/TrendPy_Webapp.ipynb
@@ -1,0 +1,516 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "2ec871f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import ipywidgets as widgets\n",
+    "from ipywidgets import interact, interactive\n",
+    "import plotly as plt\n",
+    "import plotly.express as px\n",
+    "import plotly.graph_objects as go\n",
+    "import io\n",
+    "from IPython.display import display, clear_output\n",
+    "from traitlets import traitlets\n",
+    "import methods as tm\n",
+    "import numpy as np\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9fda5bc4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "01add44a748c49c5ba4b335839fae669",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HTML(value='<h1 align=\"center\">TrendPy Webapp<h1>    <h3 align=\"center\">Visualization of trends in (time serie…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "header = widgets.HTML(\n",
+    "    value='<h1 align=\"center\">TrendPy Webapp<h1>\\\n",
+    "    <h3 align=\"center\">Visualization of trends in (time series) data<h3>')\n",
+    "header"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "33d49698",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0d656e3c4ccf4bd0825081bf1e79086a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HTML(value='<h3 align=\"center\">Upload a .csv file here<h3>')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "header2 = widgets.HTML(\n",
+    "    value='<h3 align=\"center\">Upload a .csv file here<h3>')\n",
+    "header2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7b619395",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "323e29a6fb0a4df1bccaa485f32e10bf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FileUpload(value={}, accept='.csv', description='Upload'),), layout=Layout(display='flex', just…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "box_layout = widgets.Layout(display='flex',\n",
+    "                justify_content='center')\n",
+    "uploaded_excel_file = widgets.FileUpload(accept=\".csv\", multiple=False)\n",
+    "container = widgets.HBox([uploaded_excel_file],layout=box_layout)\n",
+    "\n",
+    "display(container)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "77cc2cfd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#create pandas dataframe\n",
+    "out = widgets.Output()\n",
+    "def create_pandas_dataframe(b):\n",
+    "    \n",
+    "    # resetting everything for a new calculation\n",
+    "    with out:\n",
+    "        clear_output()\n",
+    "    with out2:\n",
+    "        clear_output()\n",
+    "    fig_widget.update_traces(x=[],y=[],selector=({'name':['trendline','datapoints']}))\n",
+    "    trend_dropdown.value='No trendline'\n",
+    "    polynomial_deg_selection.disabled=True\n",
+    "    r2_checkbox.value=False\n",
+    "    r2_checkbox.disabled=True\n",
+    "        \n",
+    "    #checking whether data has been uploaded succesfully\n",
+    "    if (uploaded_excel_file.value=={}):\n",
+    "        button.button_style='warning'\n",
+    "        with out:\n",
+    "            print(\"No data entered. Please upload a .csv file.\")\n",
+    "    \n",
+    "    else:\n",
+    "        try:\n",
+    "            \n",
+    "            \n",
+    "            button.button_style='success'\n",
+    "        \n",
+    "            #transforming the uploaded .csv file back to the type .csv in order to then create a pandas dataframe\n",
+    "            time_series_file = list(uploaded_excel_file.value.values())[0]\n",
+    "            content=time_series_file['content']\n",
+    "            content=io.StringIO(content.decode('utf-8'))\n",
+    "            time_series_data = pd.read_csv(content)\n",
+    "        \n",
+    "            #filling the drop down menus with the columns of the dataframe as options\n",
+    "            input_dropdown.options = time_series_data.select_dtypes(include='number').columns\n",
+    "            output_dropdown.options = time_series_data.select_dtypes(include='number').columns\n",
+    "            b.value = time_series_data\n",
+    "            \n",
+    "            with out: \n",
+    "                print(\"Data entered. Please select the X and Y values now. (Only works if header is in the first row of your file.)\")\n",
+    "        except:\n",
+    "            button.button_style='warning'\n",
+    "            with out:\n",
+    "                print('Invalid input! Make sure that header of the file is in first row and general format is correct!')\n",
+    "            "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3944cc3b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4b545b8e338b453688fa68c022965b7a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(LoadedButton(description='Start calculation', icon='check', style=ButtonStyle(), tooltip='Click…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f2e97e61053049f8957362f106216e94",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Output(),), layout=Layout(display='flex', justify_content='center'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#using a loaded button in order to make the pandas dataframe of the function above available outside of the function\n",
+    "class LoadedButton(widgets.Button):\n",
+    "\n",
+    "    def __init__(self, value=None, *args, **kwargs):\n",
+    "        super(LoadedButton, self).__init__(*args, **kwargs)\n",
+    "        self.add_traits(value=traitlets.Any(value))\n",
+    "\n",
+    "button = LoadedButton(description='Start calculation', disable=False, tooltip='Click to start calculation', icon='check', button_style='')\n",
+    "button.on_click(create_pandas_dataframe)\n",
+    "\n",
+    "\n",
+    "container2 = widgets.HBox([button],layout=box_layout)\n",
+    "container_out = widgets.HBox([out],layout=box_layout)\n",
+    "display(container2,container_out)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "14bde2e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7cf62ce34d864831ada3e13de4e715bd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HTML(value='<p align=\"center\" style=\"font-size:16px\">Elements down below are interactive, button above only ha…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "header4 = widgets.HTML(\n",
+    "    value='<p align=\"center\" style=\"font-size:16px\">Elements down below are interactive, button above only has to be pressed\\\n",
+    "            if a new excel-file has been uploaded<p>')\n",
+    "header4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "65377f9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# creates the graphics based on the input parameters defined in the interactive widgets below\n",
+    "def create_graphics(values_in,values_out,trend,deg=2,r2=False):\n",
+    "    if trend == 'polynomial':\n",
+    "        polynomial_deg_selection.disabled=False\n",
+    "    else:\n",
+    "        polynomial_deg_selection.disabled=True\n",
+    "        \n",
+    "    if values_in == '' or values_out=='':\n",
+    "        print(\"Please select your X and Y values in the dropdown menus above.\")\n",
+    "    else:\n",
+    "        try: # sometimes an error is occuring when user hasn't changed the standard dropdown X and Y values yet\n",
+    "             # through try/except the user does not see the error and won't notice it, because standard values are\n",
+    "             # usually not going to be used\n",
+    "            \n",
+    "            # updateing the plot based on the input data\n",
+    "            fig_widget.layout.xaxis.title = values_in\n",
+    "            fig_widget.layout.yaxis.title = values_out\n",
+    "            fig_widget.update_traces(x=button.value[values_in], y=button.value[values_out], selector=({'name':'datapoints'}))\n",
+    "            if trend!=\"No trendline\":\n",
+    "                with out2:\n",
+    "                    clear_output()\n",
+    "                r2_checkbox.disabled=False\n",
+    "                calculate_trendline(values_in, values_out, trend, deg, r2) # function that calculates and draws trendline is called\n",
+    "            else:\n",
+    "                fig_widget.update_traces(x=[],y=[],selector=({'name':'trendline'}))\n",
+    "                r2_checkbox.disabled=True\n",
+    "        except:\n",
+    "            pass\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "99257fce",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "db6250ca5e454acb992aaf11cd90ac71",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Dropdown(description='Input (X):', options=('',), value=''), Dropdown(description='Target (Y):'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1f0b613b519d4e81b0683be8ff72d002",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Dropdown(description='trendline:', options=('No trendline', 'linear', 'polynomial', 'trigonomet…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b731d796bc4240c68834693997c0c51b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Checkbox(value=False, description='Show R2 score'),), layout=Layout(display='flex', justify_con…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "081d3e5b722e4e8792a8839514ae69f0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Output(),), layout=Layout(display='flex', justify_content='center'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# defining the interactive dropdown options\n",
+    "input_dropdown = widgets.Dropdown(\n",
+    "    options=[''],\n",
+    "    value='',\n",
+    "    description='Input (X):',\n",
+    "    disabled=False,\n",
+    "    )\n",
+    "\n",
+    "output_dropdown = widgets.Dropdown(\n",
+    "    options=[''],\n",
+    "    value='',\n",
+    "    description='Target (Y):',\n",
+    "    disabled=False,\n",
+    "    )\n",
+    "\n",
+    "trend_dropdown = widgets.Dropdown(\n",
+    "    options=['No trendline','linear','polynomial','trigonometric'],\n",
+    "    value='No trendline',\n",
+    "    description='trendline:',\n",
+    "    disabled=False,\n",
+    "    )\n",
+    "\n",
+    "polynomial_deg_selection = widgets.Dropdown(\n",
+    "    options=[2,3,4,5,6],\n",
+    "    value=2,\n",
+    "    description='deg (polyn.)',\n",
+    "    disabled=True,\n",
+    "    )\n",
+    "\n",
+    "r2_checkbox = widgets.Checkbox(\n",
+    "    value=False,\n",
+    "    description='Show R2 score',\n",
+    "    disabled=False,\n",
+    "    indent=True\n",
+    ")\n",
+    "\n",
+    "# arrangement of dropdown menus\n",
+    "dropdown_elements = widgets.HBox([input_dropdown, output_dropdown], layout=box_layout)\n",
+    "trend_selection = widgets.HBox([trend_dropdown, polynomial_deg_selection], layout=box_layout)\n",
+    "r2_container = widgets.HBox([r2_checkbox],layout=box_layout)\n",
+    "\n",
+    "\n",
+    "# making all the widgets interactive, so no button needs to be pressed when changing a dropdown value      \n",
+    "out2 = widgets.interactive_output(create_graphics, {'values_in': input_dropdown, 'values_out': output_dropdown, \\\n",
+    "                                                    'trend':trend_dropdown, 'deg':polynomial_deg_selection, \\\n",
+    "                                                    'r2':r2_checkbox})\n",
+    "\n",
+    "out2_container = widgets.HBox([out2],layout=box_layout)\n",
+    "\n",
+    "display(dropdown_elements, trend_selection, r2_container, out2_container)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0ea156e8",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "445940b7286f460a97e2aa9a50a5b88e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FigureWidget({\n",
+       "    'data': [{'mode': 'markers', 'name': 'datapoints', 'type': 'scatter', 'uid': '955adbaf-876f…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# defining a figure widget, that is created in the beginning and remains static, only graphs are updated\n",
+    "# it is needed to define all needed graphs as empty ones here, so that you can use update_traces\n",
+    "fig_widget = go.FigureWidget()\n",
+    "fig_widget.layout.margin=dict(l=120, r=120, b=25, t=25)\n",
+    "fig_widget.layout.height=400\n",
+    "fig_widget.add_scatter(mode='markers', name='datapoints')\n",
+    "fig_widget.add_scatter(mode='lines', name='trendline', line=dict(shape='spline'))\n",
+    "fig_widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ddedc16a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# calculating and drawing the trendline based on selected options\n",
+    "def calculate_trendline(values_in, values_out, trend, deg, r2):\n",
+    "    sorted_df = button.value.sort_values(by=values_in) # without sorting trendlines can not be plotted correctly\n",
+    "    x_values=sorted_df[values_in].to_numpy()\n",
+    "    y_values=sorted_df[values_out].to_numpy()\n",
+    "    \n",
+    "    # in all cases coefficients are calculated first by calling function from methods.py\n",
+    "    # after that the predicted y-values are calculated by calling function from methods.py\n",
+    "    # with the data from y_pred-function it is then possible to plot the trendline\n",
+    "    # at last r2-score is calculated\n",
+    "    if trend=='linear':\n",
+    "        coefs=tm.linReg(x_values,y_values)\n",
+    "        print('coefficients: ', coefs)\n",
+    "        y_pred=tm.pred('linReg',coefs, x_values)\n",
+    "        fig_widget.update_traces(x=sorted_df[values_in], y=y_pred, selector=({'name':'trendline'}));\n",
+    "        if r2==True:\n",
+    "            r2_score = tm.r2(y_values, y_pred)\n",
+    "            print('R2-score:     ', r2_score)\n",
+    "        \n",
+    "    elif trend=='polynomial':\n",
+    "        try:\n",
+    "            coefs = tm.polReg(x_values,y_values,deg)\n",
+    "            print('coefficients: ', coefs)\n",
+    "            y_pred = tm.pred('polReg', coefs, x_values)\n",
+    "            fig_widget.update_traces(x=sorted_df[values_in], y=y_pred, selector=({'name':'trendline'}), line=dict(shape='spline'));\n",
+    "            if r2==True:\n",
+    "                r2_score = tm.r2(y_values, y_pred)\n",
+    "                print('R2-score:     ', r2_score)\n",
+    "        except:\n",
+    "            print('Selected regression might not be a good fit for the entered values! Please lower degree or choose other regression!')\n",
+    "    elif trend=='trigonometric':\n",
+    "        try:\n",
+    "            coefs = tm.trigReg(x_values,y_values)\n",
+    "            print('coefficients: ', coefs)\n",
+    "            y_pred = tm.pred('trigReg', coefs, x_values)\n",
+    "            fig_widget.update_traces(x=sorted_df[values_in], y=y_pred, selector=({'name':'trendline'}));\n",
+    "            if r2==True:\n",
+    "                r2_score = tm.r2(y_values, y_pred)\n",
+    "                print('R2-score:     ', r2_score)\n",
+    "        except:\n",
+    "            print('Selected regression might not be a good fit for the entered values! Please choose other regression!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17d6fbf2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
TrendPy Webapp is now available and can be launched by starting this jupyter notebook via Voila.
It offers an interactive UI based on ipywidgets which allows you to upload a .csv-file and after that to select numeric columns from the .csv file as X and Y values for the plot.
Currently included trendline options you can plot are linear, polynomial (up to a degree of 6) and trigonometric; also r2-score can be displayed.
New regression functions added to methods.py can be easily integrated into the Webapp in the future.